### PR TITLE
Yearn PricePerShare test

### DIFF
--- a/contracts/Ante_alETHSupplyTest.sol
+++ b/contracts/Ante_alETHSupplyTest.sol
@@ -4,7 +4,10 @@ pragma solidity >=0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/AnteTest.sol";
-import "./interfaces/IVault.sol";
+
+interface IVault {
+    function pricePerShare() external view returns (uint);
+}
 
 // Ante Test to check alETH supply never exceeds amount of ETH locked in Alchemix
 contract Ante_alETHSupplyTest is AnteTest("alETH doesn't exceed ETH locked in Alchemix") {

--- a/contracts/Ante_alUSDSupplyTest.sol
+++ b/contracts/Ante_alUSDSupplyTest.sol
@@ -4,7 +4,10 @@ pragma solidity >=0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/AnteTest.sol";
-import "./interfaces/IVault.sol";
+
+interface IVault {
+    function pricePerShare() external view returns (uint);
+}
 
 // Ante Test to check alUSD supply never exceeds amount of DAI locked in Alchemix
 contract Ante_alUSDSupplyTest is AnteTest("alUSD doesn't exceed DAI locked in Alchemix") {

--- a/contracts/Ante_yYFI_PricePerShareTest.sol
+++ b/contracts/Ante_yYFI_PricePerShareTest.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+import "./interfaces/AnteTest.sol";
+
+interface IVault {
+    function getPricePerFullShare() external view returns (uint);
+}
+
+// Ante Test to check yYFI stakeholders can withdraw their full deposit
+contract Ante_yYFI_PricePerShareTest is AnteTest("yYFI vault is in profit") {
+    // https://etherscan.io/address/0xBA2E7Fed597fd0E3e70f5130BcDbbFE06bB94fe1
+    address public constant yYFIAddr = 0xBA2E7Fed597fd0E3e70f5130BcDbbFE06bB94fe1;
+
+    IVault public yYFIVault = IVault(yYFIAddr);
+
+    constructor () {
+        protocolName = "YFI";
+        testedContracts = [yYFIAddr];
+    }
+    
+    function checkTestPasses() public view override returns (bool) {
+        return (uint(yYFIVault.getPricePerFullShare()) >= 1e18);
+    }
+}

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: MIT
-
-pragma solidity >=0.8.0;
-
-interface IVault {
-    function pricePerShare() external view returns (uint);
-}


### PR DESCRIPTION
Tests for yYFI PricePerShare > 1.

Removed IVault because it seems some Yearn vaults use PricePerShare while others use getPricePerFullShare. Might be better to include the right interface with the ante test?