### PR TITLE
Add tWETH issued fully backed by WETH Ante Test for Tokemak

### DIFF
--- a/contracts/tokemak/AnteTWETHTest.sol
+++ b/contracts/tokemak/AnteTWETHTest.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.7.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../AnteTest.sol";
+import "./interfaces/IManager.sol";
+import "./interfaces/ILiquidityPool.sol";
+
+/// @title Tokemak tWETH issued fully backed by WETH
+/// @notice Ante Test to check Tokemak minted tWETH matches deposited WETH
+contract AnteTWETHTest is AnteTest("Tokemak tWETH issued fully backed by WETH") {
+  using SafeMath for uint256;
+
+  IERC20 public wETH9Token;
+  IERC20 public tWETHToken;
+  IManager public tokemakManager;
+
+  /// @param _tokemakManagerAddr Tokemak Pool Manager contract address (0xa86e412109f77c45a3bc1c5870b880492fb86a14 on mainnet)
+  /// @param _tWETHAddr tWETH contract address (0xd3d13a578a53685b4ac36a1bab31912d2b2a2f36 on mainnet)
+  /// @param _wETH9Addr WETH9 contract address (0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 on mainnet)
+  constructor(address _tokemakManagerAddr, address _tWETHAddr, address _wETH9Addr) {
+      wETH9Token = IERC20(_wETH9Addr);
+      tWETHToken = IERC20(_tWETHAddr);
+
+      tokemakManager = IManager(_tokemakManagerAddr);
+      protocolName = "tWETH Pool";
+      testedContracts = [_tWETHAddr, _tokemakManagerAddr];
+  }
+
+  /// @notice test to check tWETH token supply against total tokemak WETH balance
+  /// @return true if tWETH token supply equals total WETH balance
+  /// @dev Invariant holds for current tokemak implementation.
+  /// @dev May not hold once liquidity deployment is implemented.
+  function checkTestPasses() external view override returns (bool) {
+    uint256 currentTVL;
+    address[] memory pools;
+
+    // During rollover, WETH could temporarily be moved to the manager, usually 0.
+    currentTVL = currentTVL.add(wETH9Token.balanceOf(address(tokemakManager))); // in WETH
+
+    pools = tokemakManager.getPools();
+    for (uint256 i = 0; i < pools.length; i++) {
+      ILiquidityPool pool = ILiquidityPool(pools[i]);
+      // Pools has heterogeneous underlyers, only consider WETH pools
+      if (address(pool.underlyer()) == address(wETH9Token)) {
+        currentTVL = currentTVL.add(wETH9Token.balanceOf(pools[i]));
+      }
+    }
+    return currentTVL >= tWETHToken.totalSupply();
+  }
+}

--- a/contracts/tokemak/interfaces/ILiquidityPool.sol
+++ b/contracts/tokemak/interfaces/ILiquidityPool.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.7.6; // modified from original 0.6.11
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "../interfaces/IManager.sol";
+// FROM https://raw.githubusercontent.com/Tokemak/tokemak-smart-contracts-public/main/contracts/interfaces/ILiquidityPool.sol
+
+/// @title Interface for Pool
+/// @notice Allows users to deposit ERC-20 tokens to be deployed to market makers.
+/// @notice Mints 1:1 fToken on deposit, represeting an IOU for the undelrying token that is freely transferable.
+/// @notice Holders of fTokens earn rewards based on duration their tokens were deployed and the demand for that asset.
+/// @notice Holders of fTokens can redeem for underlying asset after issuing requestWithdrawal and waiting for the next cycle.
+interface ILiquidityPool {
+
+    struct WithdrawalInfo {
+        uint256 minCycle;
+        uint256 amount;
+    }
+
+    /// @notice Transfers amount of underlying token from user to this pool and mints fToken to the msg.sender.
+    /// @notice Depositor must have previously granted transfer approval to the pool via underlying token contract.
+    /// @notice Liquidity deposited is deployed on the next cycle - unless a withdrawal request is submitted, in which case the liquidity will be withheld.
+    function deposit(uint256 amount) external;
+
+    /// @notice Transfers amount of underlying token from user to this pool and mints fToken to the account.
+    /// @notice Depositor must have previously granted transfer approval to the pool via underlying token contract.
+    /// @notice Liquidity deposited is deployed on the next cycle - unless a withdrawal request is submitted, in which case the liquidity will be withheld.
+    function depositFor(address account, uint256 amount) external;
+
+    /// @notice Requests that the manager prepare funds for withdrawal next cycle
+    /// @notice Invoking this function when sender already has a currently pending request will overwrite that requested amount and reset the cycle timer
+    /// @param amount Amount of fTokens requested to be redeemed
+    function requestWithdrawal(uint256 amount) external;
+
+    function approveManager(uint256 amount) external;
+
+    /// @notice Sender must first invoke requestWithdrawal in a previous cycle
+    /// @notice This function will burn the fAsset and transfers underlying asset back to sender
+    /// @notice Will execute a partial withdrawal if either available liquidity or previously requested amount is insufficient
+    /// @param amount Amount of fTokens to redeem, value can be in excess of available tokens, operation will be reduced to maximum permissible
+    function withdraw(uint256 amount) external;
+
+    /// @return Reference to the underlying ERC-20 contract
+    function underlyer() external view returns (ERC20Upgradeable);
+
+    /// @return Amount of liquidity that should not be deployed for market making (this liquidity will be used for completing requested withdrawals)
+    function withheldLiquidity() external view returns (uint256);
+
+    /// @notice Get withdraw requests for an account
+    /// @param account User account to check
+    /// @return minCycle Cycle - block number - that must be active before withdraw is allowed, amount Token amount requested
+    function requestedWithdrawals(address account) external view returns (uint256, uint256);
+
+    /// @notice Pause deposits on the pool. Withdraws still allowed
+    function pause() external;
+
+    /// @notice Unpause deposits on the pool.
+    function unpause() external;
+}

--- a/contracts/tokemak/interfaces/IManager.sol
+++ b/contracts/tokemak/interfaces/IManager.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.7.6; // modified from original 0.6.11
+pragma experimental ABIEncoderV2;
+
+// FROM: https://raw.githubusercontent.com/Tokemak/tokemak-smart-contracts-public/main/contracts/interfaces/IManager.sol
+interface IManager {
+
+    // bytes can take on the form of deploying or recovering liquidity
+    struct ControllerTransferData {
+        bytes32 controllerId; // controller to target
+        bytes data; // data the controller will pass
+    }
+
+    struct PoolTransferData {
+        address pool; // pool to target
+        uint256 amount; // amount to transfer
+    }
+
+    struct MaintenanceExecution {
+         ControllerTransferData[] cycleSteps;
+    }
+
+    struct RolloverExecution {
+        PoolTransferData[] poolData;
+        ControllerTransferData[] cycleSteps;
+        address[] poolsForWithdraw; //Pools to target for manager -> pool transfer
+        bool complete; //Whether to mark the rollover complete
+        string rewardsIpfsHash;
+    }
+
+    event ControllerRegistered(bytes32 id, address controller);
+    event ControllerUnregistered(bytes32 id, address controller);
+    event PoolRegistered(address pool);
+    event PoolUnregistered(address pool);
+    event CycleDurationSet(uint256 duration);
+    event LiquidityMovedToManager(address pool, uint256 amount);
+    event DeploymentStepExecuted(bytes32 controller, address adapaterAddress, bytes data);
+    event LiquidityMovedToPool(address pool, uint256 amount);
+    event CycleRolloverStarted(uint256 blockNumber);
+    event CycleRolloverComplete(uint256 blockNumber);
+
+    function registerController(bytes32 id, address controller) external;
+
+    function registerPool(address pool) external;
+
+    function unRegisterController(bytes32 id) external;
+
+    function unRegisterPool(address pool) external;
+
+    function getPools() external view returns (address[] memory);
+
+    function getControllers() external view returns (bytes32[] memory);
+
+    function setCycleDuration(uint256 duration) external;
+
+    function startCycleRollover() external;
+
+    function executeMaintenance(MaintenanceExecution calldata params) external;
+
+    function executeRollover(RolloverExecution calldata params) external;
+
+    function completeRollover(string calldata rewardsIpfsHash) external;
+
+    function cycleRewardsHashes(uint256 index) external view returns (string memory);
+
+    function getCurrentCycle() external view returns (uint256);
+
+    function getCurrentCycleIndex() external view returns (uint256);
+
+    function getCycleDuration() external view returns (uint256);
+
+    function getRolloverStatus() external view returns (bool);
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@nomiclabs/hardhat-etherscan": "^2.1.6",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.4.1",
+    "@openzeppelin/contracts-upgradeable": "^3.4.1",
     "@tenderly/hardhat-tenderly": "^1.0.12",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.3.0",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -51,3 +51,18 @@ export async function calculateGasUsed(txpromise: any): Promise<BigNumber> {
   const txreceipt = await txpromise.wait();
   return txreceipt.effectiveGasPrice.mul(txreceipt.cumulativeGasUsed);
 }
+
+export async function runAsSigner(
+  signerAddr: string,
+  fn: () => Promise<void>
+): Promise<void> {
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [signerAddr],
+    });
+    await fn();
+    await hre.network.provider.request({
+      method: "hardhat_stopImpersonatingAccount",
+      params: [signerAddr],
+    });
+}

--- a/test/tokemak/ante_tweth_test.spec.ts
+++ b/test/tokemak/ante_tweth_test.spec.ts
@@ -1,0 +1,79 @@
+import hre from 'hardhat';
+const { waffle, ethers } = hre;
+
+import { AnteTWETHTest__factory, AnteTWETHTest, IERC20 } from '../../typechain';
+
+import { evmSnapshot, evmRevert, runAsSigner } from '../helpers';
+import { expect } from 'chai';
+
+describe('AnteTWETHTest', function () {
+  let test: AnteTWETHTest;
+
+  let globalSnapshotId: string;
+
+  const INITIAL_TESTING_ETH = ethers.utils.parseEther('10.0').toHexString();
+
+  const _tokemakManagerAddr = '0xa86e412109f77c45a3bc1c5870b880492fb86a14'; // Tokemak Manager
+  const _WETH9Addr = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'; // WETH9 Token
+  const _tWETHAddr = '0xd3d13a578a53685b4ac36a1bab31912d2b2a2f36'; // Tokemak WETH Pool
+
+  beforeEach(async () => {
+    globalSnapshotId = await evmSnapshot();
+
+    const [deployer] = waffle.provider.getWallets();
+    const factory = (await ethers.getContractFactory('AnteTWETHTest', deployer)) as AnteTWETHTest__factory;
+    test = await factory.deploy(_tokemakManagerAddr, _tWETHAddr, _WETH9Addr);
+    await test.deployed();
+  });
+
+  afterEach(async () => {
+    await evmRevert(globalSnapshotId);
+  });
+
+  it('should pass', async () => {
+    expect(await test.checkTestPasses()).to.be.true;
+  });
+  it('should pass after external wETH deposits', async () => {
+    const BENEVOLENT_WETH_DONOR = '0x030ba81f1c18d280636f32af80b9aad02cf0854e'; // Aave: aWETH Token V2 Contract
+    await runAsSigner(BENEVOLENT_WETH_DONOR, async () => {
+      const donor = await ethers.getSigner(BENEVOLENT_WETH_DONOR);
+      await hre.network.provider.request({
+        method: "hardhat_setBalance",
+        params: [BENEVOLENT_WETH_DONOR, INITIAL_TESTING_ETH],
+      });
+
+      const wETH9Token = <IERC20>await ethers.getContractAt('contracts/interfaces/IERC20.sol:IERC20', _WETH9Addr, donor);
+      const tWETHToken = <IERC20>await ethers.getContractAt('contracts/interfaces/IERC20.sol:IERC20', _tWETHAddr);
+
+      await wETH9Token.transferFrom(BENEVOLENT_WETH_DONOR, _tWETHAddr, ethers.utils.parseUnits("4242", 'gwei'));
+
+      const wETHBalancePostTransfer = await wETH9Token.balanceOf(_tWETHAddr);
+      const tWETHSupply = await tWETHToken.totalSupply();
+
+      expect(wETHBalancePostTransfer).to.be.above(tWETHSupply);
+      expect(await test.checkTestPasses()).to.be.true;
+    });
+  });
+
+  it('should fail after wETH withdrawal to external', async () => {
+    const LUCKY_WETH_RECIPIENT = '0x030ba81f1c18d280636f32af80b9aad02cf0854e'; // Aave: aWETH Token V2 Contract
+    await runAsSigner(_tWETHAddr, async () => {
+      const donor = await ethers.getSigner(_tWETHAddr);
+      await hre.network.provider.request({
+        method: "hardhat_setBalance",
+        params: [_tWETHAddr, INITIAL_TESTING_ETH],
+      });
+
+      const wETH9Token = <IERC20>await ethers.getContractAt('contracts/interfaces/IERC20.sol:IERC20', _WETH9Addr, donor);
+      const tWETHToken = <IERC20>await ethers.getContractAt('contracts/interfaces/IERC20.sol:IERC20', _tWETHAddr);
+
+      await wETH9Token.transfer(LUCKY_WETH_RECIPIENT, ethers.utils.parseUnits("1337", 'gwei'));
+
+      const wETHBalancePostTransfer = await wETH9Token.balanceOf(_tWETHAddr);
+      const tWETHSupply = await tWETHToken.totalSupply();
+
+      expect(wETHBalancePostTransfer).to.be.below(tWETHSupply);
+      expect(await test.checkTestPasses()).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Adding a simple test for the Tokemak protocol that checks the following invariant: tWETH tokens issued by tokemak are fully backed by the aggregate WETH balance across Tokemak pools.