### PR TITLE
(1/2) Ante test for BAYC max supply

### DIFF
--- a/contracts/bored_ape/AnteBoredApe_MaxSupply.sol
+++ b/contracts/bored_ape/AnteBoredApe_MaxSupply.sol
@@ -4,10 +4,9 @@ pragma solidity ^0.8.0;
 
 import "../AnteTest.sol";
 
-//TODO: can this extend IERC721Enumerable to inherit totalSupply() implicitly?
 interface BoredApes {
     //TODO: silence linter (variable must be mixedCase)
-    uint256 public MAX_APES;
+    function MAX_APES() external view returns (uint256);
 
     function totalSupply() external view returns (uint256);
 }

--- a/contracts/bored_ape/AnteBoredApe_MaxSupply.sol
+++ b/contracts/bored_ape/AnteBoredApe_MaxSupply.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../AnteTest.sol";
+
+//TODO: can this extend IERC721Enumerable to inherit totalSupply() implicitly?
+interface BoredApes {
+    //TODO: silence linter (variable must be mixedCase)
+    uint256 public MAX_APES;
+
+    function totalSupply() external view returns (uint256);
+}
+
+/// @title AnteBoredApeMaxSupplyTest
+/// @notice Ensure that minted BAYC tokens are less than or equal 10,000 as advertised
+contract AnteBoredApeMaxSupplyTest is AnteTest("Ensure that BAYC token supply is capped at 10,000") {
+    // https://etherscan.io/address/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d
+    address public constant BAYC_ADDR = 0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D;
+    BoredApes public constant BAYC_CONTRACT = BoredApes(BAYC_ADDR);
+
+    /**
+     * Network: Mainnet
+     * Address: 0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d
+     */
+    constructor() {
+        protocolName = "BAYC";
+        testedContracts = [BAYC_ADDR];
+    }
+
+    /// @return if the BAYC supply <= max tokens (10,000)
+    function checkTestPasses() public view override returns (bool) {
+        return (BAYC_CONTRACT.totalSupply() < BAYC_CONTRACT.MAX_APES());
+    }
+}

--- a/contracts/bored_ape/AnteBoredApe_MaxSupply.sol
+++ b/contracts/bored_ape/AnteBoredApe_MaxSupply.sol
@@ -29,6 +29,6 @@ contract AnteBoredApeMaxSupplyTest is AnteTest("Ensure that BAYC token supply is
 
     /// @return if the BAYC supply <= max tokens (10,000)
     function checkTestPasses() public view override returns (bool) {
-        return (BAYC_CONTRACT.totalSupply() < BAYC_CONTRACT.MAX_APES());
+        return (BAYC_CONTRACT.totalSupply() <= BAYC_CONTRACT.MAX_APES());
     }
 }

--- a/test/bored_ape/ante_bored_ape_token_supply_test.spec.ts
+++ b/test/bored_ape/ante_bored_ape_token_supply_test.spec.ts
@@ -1,0 +1,33 @@
+import hre from 'hardhat';
+const { waffle } = hre;
+
+import { AnteBoredApeMaxSupplyTest, AnteBoredApeMaxSupplyTest__factory } from '../../typechain';
+
+import { evmSnapshot, evmRevert } from '../helpers';
+import { expect } from 'chai';
+
+describe('AnteBoredApeMaxSupplyTest', function () {
+  let test: AnteBoredApeMaxSupplyTest;
+
+  let globalSnapshotId: string;
+
+  before(async () => {
+    globalSnapshotId = await evmSnapshot();
+
+    const [deployer] = waffle.provider.getWallets();
+    const factory = (await hre.ethers.getContractFactory(
+      'AnteBoredApeMaxSupplyTest',
+      deployer
+    )) as AnteBoredApeMaxSupplyTest__factory;
+    test = await factory.deploy();
+    await test.deployed();
+  });
+
+  after(async () => {
+    await evmRevert(globalSnapshotId);
+  });
+
+  it('should pass', async () => {
+    expect(await test.checkTestPasses()).to.be.true;
+  });
+});


### PR DESCRIPTION
# Purpose
- There is a function `reserveApes` in the [BAYC contract code ](https://etherscan.io/address/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d#code) that can allow Yuga Labs to mint additional apes, over the 10k advertised limit. 
- this test is to assert the invariant that there will never be more than 10,000 bored apes.
- to add the first non de-fi test in the annte-community-test repository

# Testing
- boilerplate unit test
- see https://github.com/antefinance/ante-community-tests/pull/100 for more

### Update
As soon as I opened, I googled this known issue and Yuga labs revoked their access today (June 8)
- [news story](https://www.theblockcrypto.com/post/150764/yuga-labs-revokes-code-that-allowed-creation-of-infinite-bored-apes)
- [trasnfer ownership transaction](https://etherscan.io/tx/0x2c903f1d6bf8a0d07a16c947a752b3c6e9338411ac372ea0444445f7d0281e6c#eventlog)
Still useful test to have