### PR TITLE
Add MetaStreet Vault Solvency test

### DIFF
--- a/contracts/metastreet/AnteMetaStreetVaultSolvencyTest.sol
+++ b/contracts/metastreet/AnteMetaStreetVaultSolvencyTest.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../AnteTest.sol";
+
+interface IVaultAbridged {
+    enum TrancheId {
+        Senior,
+        Junior
+    }
+
+    function trancheState(TrancheId trancheId)
+        external
+        view
+        returns (
+            uint256 realizedValue,
+            uint256 estimatedValue,
+            uint256 pendingRedemptions,
+            uint256 redemptionQueue,
+            uint256 processedRedemptionQueue,
+            uint256 depositSharePrice,
+            uint256 redemptionSharePrice_
+        );
+}
+
+// @title MetaStreet Vault Junior Tranche Solvency Test
+// @notice Ante Test to check if a MetaStreet Vault's junior tranche is solvent
+contract AnteMetaStreetVaultSolvencyTest is AnteTest("Ensure that a MetaStreet Vault's Junior Tranche is solvent") {
+    IVaultAbridged private vault;
+
+    constructor(address _vault) {
+        protocolName = "MetaStreet";
+        testedContracts.push(_vault);
+
+        vault = IVaultAbridged(_vault);
+    }
+
+    // @notice Check if a Vault's junior tranche is solvent
+    // @return true if Vault's junior tranche is solvent, otherwise false
+    function checkTestPasses() external view override returns (bool) {
+        (uint256 realizedValue, , uint256 pendingRedemptions, , , , ) = vault.trancheState(
+            IVaultAbridged.TrancheId.Junior
+        );
+
+        return realizedValue >= pendingRedemptions;
+    }
+}

--- a/test/metastreet/AnteMetaStreetVaultSolvencyTest.spec.ts
+++ b/test/metastreet/AnteMetaStreetVaultSolvencyTest.spec.ts
@@ -1,0 +1,34 @@
+import hre from 'hardhat';
+const { waffle } = hre;
+
+import { AnteMetaStreetVaultSolvencyTest, AnteMetaStreetVaultSolvencyTest__factory } from '../../typechain';
+
+import { evmSnapshot, evmRevert } from '../helpers';
+import { expect } from 'chai';
+
+describe('AnteMetaStreetVaultSolvencyTest', function () {
+  let test: AnteMetaStreetVaultSolvencyTest;
+
+  let globalSnapshotId: string;
+
+  before(async () => {
+    globalSnapshotId = await evmSnapshot();
+
+    const [deployer] = waffle.provider.getWallets();
+
+    const factory = (await hre.ethers.getContractFactory(
+      'AnteMetaStreetVaultSolvencyTest',
+      deployer
+    )) as AnteMetaStreetVaultSolvencyTest__factory;
+    test = await factory.deploy('0x2542549517ee2dd58E550Db22a104A05035E5016');
+    await test.deployed();
+  });
+
+  after(async () => {
+    await evmRevert(globalSnapshotId);
+  });
+
+  it('should pass', async () => {
+    expect(await test.checkTestPasses()).to.be.true;
+  });
+});


### PR DESCRIPTION
This PR adds an Ante test to check the solvency of a MetaStreet Vault's junior tranche. The Ante test can be deployed for any MetaStreet Vault by specifying its address in the test constructor.